### PR TITLE
[WIP] Now we convert the index.html to json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,69 @@
 /* jshint node: true */
 'use strict';
 
+var cheerio   = require('cheerio');
+var path      = require('path');
+var fs        = require('fs');
+var RSVP      = require('rsvp');
+var denodeify = RSVP.denodeify;
+
+var readFile  = denodeify(fs.readFile);
+var writeFile = denodeify(fs.writeFile);
+
 module.exports = {
-  name: 'ember-cli-deploy-json-config'
+  name: 'ember-cli-deploy-json-config',
+
+  createDeployPlugin: function(options) {
+    return {
+      name: options.name,
+
+      build: function(context) {
+        var project    = context.project;
+        var root       = project.root;
+        var distPath   = path.join(root, 'dist');
+        var indexPath  = path.join(distPath, 'index.html');
+        var outputPath = path.join(distPath, 'index.json');
+
+        return readFile(indexPath)
+          .then(this._extractConfig.bind(this), this._handleMissingFile)
+          .then(writeFile.bind(this, outputPath));
+      }.bind(this)
+    }
+  },
+
+  _extractConfig: function(data) {
+    var $ = cheerio.load(data.toString());
+    var json = {
+      base: this._get($, 'base', ['href']),
+      meta: this._get($, 'meta[name*="/config/environment"]', ['name', 'content']),
+      link: this._get($, 'link', ['rel', 'href']),
+      script: this._get($, 'script', ['src'])
+    };
+
+    return RSVP.resolve(JSON.stringify(json));
+  },
+
+  _handleMissingFile: function() {
+    return RSVP.resolve();
+  },
+
+  _get: function($, selector, attributes) {
+    attributes = attributes || [];
+    var config = [];
+    var $tags = $(selector);
+
+    $tags.each(function() {
+      var $tag = $(this);
+
+      var data = attributes.reduce(function(data, attribute) {
+        data[attribute] = $tag.attr(attribute);
+
+        return data;
+      }, {});
+
+      config.push(data);
+    });
+
+    return config;
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-deploy-json-config",
-  "version": "0.0.0",
-  "description": "The default blueprint for ember-cli addons.",
+  "version": "0.1.0",
+  "description": "An ember-cli-deploy plugin to convert index.html to json config",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -11,14 +11,15 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "https://github.com/zapnito/ember-cli-deploy-json-config",
   "engines": {
     "node": ">= 0.10.0"
   },
-  "author": "",
+  "author": "Aaron Chambers and Jon Beer",
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
+    "cheerio": "^0.19.0",
     "ember-cli": "0.2.3",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-content-security-policy": "0.4.0",
@@ -29,17 +30,20 @@
     "ember-cli-qunit": "0.3.10",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
-    "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-try": "0.0.4"
+    "ember-export-application-global": "^1.0.2",
+    "ember-try": "0.0.4",
+    "rsvp": "^3.0.18"
   },
   "keywords": [
-    "ember-addon"
+    "ember-addon",
+    "ember-cli-deploy-plugin"
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-deploy-build"
   }
 }


### PR DESCRIPTION
This PR will:

- Build an `index.json` file from the `index.html` file.

The idea behind this is that the config can be pushed somewhere, such as Redis, and then retrieved by a server and merged into a template before being served.  This will be handy when the server that is serving the ember app wants to do some templating before serving the ember app, instead of just serving the index.html straight up.