### PR TITLE
[WIP] Build index.json from index.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+
+tests/fixtures/dist/index.json

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+machine:
+  node:
+   version: 0.12.0
+
+dependencies:
+  pre:
+    - npm install -g bower
+  override:
+    - npm i
+    - bower i

--- a/index.js
+++ b/index.js
@@ -1,6 +1,69 @@
 /* jshint node: true */
 'use strict';
 
+var cheerio   = require('cheerio');
+var path      = require('path');
+var fs        = require('fs');
+var RSVP      = require('rsvp');
+var denodeify = RSVP.denodeify;
+
+var readFile  = denodeify(fs.readFile);
+var writeFile = denodeify(fs.writeFile);
+
 module.exports = {
-  name: 'ember-cli-deploy-json-config'
+  name: 'ember-cli-deploy-json-config',
+
+  createDeployPlugin: function(options) {
+    return {
+      name: options.name,
+
+      build: function(context) {
+        var project    = context.project;
+        var root       = project.root;
+        var distPath   = path.join(root, 'dist');
+        var indexPath  = path.join(distPath, 'index.html');
+        var outputPath = path.join(distPath, 'index.json');
+
+        return readFile(indexPath)
+          .then(this._extractConfig.bind(this), this._handleMissingFile)
+          .then(writeFile.bind(this, outputPath));
+      }.bind(this)
+    }
+  },
+
+  _extractConfig: function(data) {
+    var $ = cheerio.load(data.toString());
+    var json = {
+      base: this._get($, 'base', ['href']),
+      meta: this._get($, 'meta[name*="/config/environment"]', ['name', 'content']),
+      link: this._get($, 'link', ['rel', 'href']),
+      script: this._get($, 'script', ['src'])
+    };
+
+    return RSVP.resolve(JSON.stringify(json));
+  },
+
+  _handleMissingFile: function() {
+    return RSVP.resolve();
+  },
+
+  _get: function($, selector, attributes) {
+    attributes = attributes || [];
+    var config = [];
+    var $tags = $(selector);
+
+    $tags.each(function() {
+      var $tag = $(this);
+
+      var data = attributes.reduce(function(data, attribute) {
+        data[attribute] = $tag.attr(attribute);
+
+        return data;
+      }, {});
+
+      config.push(data);
+    });
+
+    return config;
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-deploy-json-config",
-  "version": "0.0.0",
-  "description": "The default blueprint for ember-cli addons.",
+  "version": "0.1.0",
+  "description": "An ember-cli-deploy plugin to convert index.html to json config",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -11,11 +11,11 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "https://github.com/zapnito/ember-cli-deploy-json-config",
   "engines": {
     "node": ">= 0.10.0"
   },
-  "author": "",
+  "author": "Aaron Chambers and Jon Beer",
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
@@ -29,17 +29,21 @@
     "ember-cli-qunit": "0.3.10",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
-    "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-export-application-global": "^1.0.2",
     "ember-try": "0.0.4"
   },
   "keywords": [
-    "ember-addon"
+    "ember-addon",
+    "ember-cli-deploy-plugin"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "cheerio": "^0.19.0",
+    "rsvp": "^3.0.18"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-deploy-build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember try:testall"
+    "test": "node tests/runner.js"
   },
   "repository": "https://github.com/zapnito/ember-cli-deploy-json-config",
   "engines": {
@@ -19,6 +19,8 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
+    "chai": "^2.2.0",
+    "chai-as-promised": "^5.0.0",
     "ember-cli": "0.2.3",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-content-security-policy": "0.4.0",
@@ -31,7 +33,9 @@
     "ember-data": "1.0.0-beta.16.1",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-try": "0.0.4"
+    "ember-try": "0.0.4",
+    "glob": "^5.0.5",
+    "mocha": "^2.2.4"
   },
   "keywords": [
     "ember-addon",

--- a/tests/fixtures/dist/index.html
+++ b/tests/fixtures/dist/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>DummyApp</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <base href="/" />
+    <meta name="my-app/config/environment" content="some-config-values" />
+
+    <link rel="stylesheet" href="assets/vendor.css">
+    <link rel="stylesheet" href="assets/app.css">
+
+  </head>
+  <body>
+    <script src="assets/vendor.js"></script>
+    <script src="assets/app.js"></script>
+  </body>
+</html>
+

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var glob = require('glob');
+var Mocha = require('mocha');
+
+var mocha = new Mocha({
+  reporter: 'spec'
+});
+
+var arg = process.argv[2];
+var root = 'tests/';
+
+function addFiles(mocha, files) {
+  glob.sync(root + files).forEach(mocha.addFile.bind(mocha));
+}
+
+addFiles(mocha, '/**/*-nodetest.js');
+
+if (arg === 'all') {
+  addFiles(mocha, '/**/*-nodetest-slow.js');
+}
+
+mocha.run(function(failures) {
+  process.on('exit', function() {
+    process.exit(failures);
+  });
+});

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var fs     = require('fs');
+var path   = require('path');
+var assert = require('ember-cli/tests/helpers/assert');
+
+describe('the deploy plugin object', function() {
+  var subject;
+  var fakeRoot;
+
+  before(function() {
+    subject = require('../../index');
+    fakeRoot =  process.cwd() + '/tests/fixtures';
+  });
+
+  beforeEach(function() {
+    var jsonPath = fakeRoot + '/dist/index.json';
+    if (fs.existsSync(jsonPath)) {
+      fs.unlinkSync(jsonPath);
+    }
+  });
+
+  it('has a name', function() {
+    var result = subject.createDeployPlugin({
+      name: 'test-plugin'
+    });
+
+    assert.equal('test-plugin', result.name);
+  });
+
+  it('implements the correct hooks', function() {
+    var result = subject.createDeployPlugin({
+      name: 'test-plugin'
+    });
+
+    assert.equal(typeof result.build, 'function');
+  });
+
+  describe('build hook', function() {
+    it('generates index.json from index.html', function(done) {
+      var build = subject.createDeployPlugin({
+        name: 'test-plugin'
+      }).build;
+
+      var buildOptions = {
+        project: { root: fakeRoot }
+      };
+
+      build(buildOptions)
+        .then(function() {
+          var json = require(fakeRoot + '/dist/index.json');
+
+          assert.equal(Object.keys(json).length, 4);
+
+          assert.deepEqual(json.base[0], { href: '/' });
+          assert.deepEqual(json.meta[0], { name: 'my-app/config/environment', content: 'some-config-values' });
+          assert.deepEqual(json.link[0], { rel: 'stylesheet', href: 'assets/vendor.css' });
+          assert.deepEqual(json.link[1], { rel: 'stylesheet', href: 'assets/app.css' });
+          assert.deepEqual(json.script[0], { src: 'assets/vendor.js' });
+          assert.deepEqual(json.script[1], { src: 'assets/app.js' });
+
+          done();
+        })
+        .catch(function(error) {
+          done(error);
+        });
+    });
+  });
+});


### PR DESCRIPTION
This PR will:

- Build an `index.json` file from the `index.html` file.

The idea behind this is that the config can be pushed somewhere, such as Redis, and then retrieved by a server and merged into a template before being served.  This will be handy when the server that is serving the ember app wants to do some templating before serving the ember app, instead of just serving the index.html straight up.