### PR TITLE
[WIP] Updated to be in line with how ember-cli-deploy handles context data

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,18 +17,18 @@ module.exports = {
     return {
       name: options.name,
 
-      build: function(context) {
-        var project    = context.project;
+      didBuild: function(context) {
+        var deployment = context.deployment;
+        var project    = deployment.project;
         var root       = project.root;
-        var distPath   = path.join(root, 'dist');
-        var indexPath  = path.join(distPath, 'index.html');
-        var outputPath = path.join(distPath, 'index.json');
+        var indexPath  = path.join(root, (context.indexPath || 'dist/index.html'));
+        var outputPath = path.join(path.dirname(indexPath), 'index.json');
 
         return readFile(indexPath)
           .then(this._extractConfig.bind(this), this._handleMissingFile)
           .then(writeFile.bind(this, outputPath))
           .then(function() {
-            context.data.indexPath = outputPath;
+            return { indexPath: outputPath };
           });
       }.bind(this)
     }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "rsvp": "^3.0.18"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
-    "after": "ember-cli-deploy-build"
+    "configPath": "tests/dummy/config"
   }
 }

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -33,21 +33,24 @@ describe('the deploy plugin object', function() {
       name: 'test-plugin'
     });
 
-    assert.equal(typeof result.build, 'function');
+    assert.equal(typeof result.didBuild, 'function');
   });
 
-  describe('build hook', function() {
-    it('generates index.json from index.html', function(done) {
-      var build = subject.createDeployPlugin({
+  describe('didBuild hook', function() {
+    it('generates index.json from index.html', function() {
+      var didBuild = subject.createDeployPlugin({
         name: 'test-plugin'
-      }).build;
+      }).didBuild;
 
-      var buildOptions = {
-        project: { root: fakeRoot },
+      var context = {
+        deployment: {
+          project: { root: fakeRoot }
+        },
         data: {}
       };
 
-      build(buildOptions)
+      var promise = didBuild(context);
+      return assert.isFulfilled(promise)
         .then(function() {
           var json = require(fakeRoot + '/dist/index.json');
 
@@ -59,33 +62,26 @@ describe('the deploy plugin object', function() {
           assert.deepEqual(json.link[1], { rel: 'stylesheet', href: 'assets/app.css' });
           assert.deepEqual(json.script[0], { src: 'assets/vendor.js' });
           assert.deepEqual(json.script[1], { src: 'assets/app.js' });
-
-          done();
-        })
-        .catch(function(error) {
-          done(error);
         });
     });
 
-    it ('sets the index.json path in the data object', function(done) {
-      var build = subject.createDeployPlugin({
+    it ('returns the index.json path', function() {
+      var didBuild = subject.createDeployPlugin({
         name: 'test-plugin'
-      }).build;
+      }).didBuild;
 
       var data = {};
-      var buildOptions = {
-        project: { root: fakeRoot },
-        data: data
+      var context = {
+        indexPath: 'dist/index.html',
+        deployment: {
+          project: { root: fakeRoot }
+        }
       };
 
-      build(buildOptions)
-        .then(function() {
-          assert.deepEqual(data, { indexPath: fakeRoot + '/dist/index.json' });
-
-          done()
-        })
-        .catch(function(error) {
-          done(error);
+      var promise = didBuild(context);
+      return assert.isFulfilled(promise)
+        .then(function(result) {
+          assert.equal(result.indexPath, fakeRoot + '/dist/index.json');
         });
     });
   });


### PR DESCRIPTION
This PR will do the following things:

- Access deploy context from `context.deployment`
- Get `index.html` path from `context.indexPath`
- Put `index.json` in the same directory as `index.html`
- Return the new `indexPath` to be merged by the pipeline into the context